### PR TITLE
Fix ESLint error: Replace confirm with window.confirm

### DIFF
--- a/src/pages/AdminPage.js
+++ b/src/pages/AdminPage.js
@@ -306,7 +306,7 @@ const AdminPage = () => {
   }
 
   const handleDeleteReview = async (reviewId) => {
-    if (confirm('Are you sure you want to delete this review?')) {
+    if (window.confirm('Are you sure you want to delete this review?')) {
       try {
         await deleteReview(reviewId)
         await loadReviews() // Reload reviews
@@ -950,4 +950,4 @@ const AdminPage = () => {
   }
 }
 
-export default AdminPage 
+export default AdminPage


### PR DESCRIPTION
## 🐛 Fix ESLint Error

**Problem**: Build was failing due to ESLint error in `src/pages/AdminPage.js`
- ESLint error: `Unexpected use of 'confirm' no-restricted-globals` on line 309

**Solution**: 
- Changed `confirm('Are you sure you want to delete this review?')` 
- To `window.confirm('Are you sure you want to delete this review?')`

**Impact**:
- ✅ Fixes Vercel deployment failure
- ✅ Resolves ESLint error 
- ✅ Maintains same functionality
- ✅ Follows ESLint best practices for global references

**Testing**:
- ✅ Local build passes without errors
- ✅ Functionality remains unchanged

This change should resolve the Vercel deployment issues.